### PR TITLE
Added new interface with keypath

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,6 @@ thiserror = "2.0.12"
 missing_docs = "warn"
 
 [lints.clippy]
-unwrap_used = "warn"
 pedantic = "warn"
+unwrap_used = "warn"
+expect_used = "warn"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,2 @@
-
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true

--- a/src/keypath.rs
+++ b/src/keypath.rs
@@ -1,0 +1,116 @@
+//! Parsing for keypaths, which are of the form:
+//!
+//! a.b.c.d
+//!
+//! The only things precluded from this design are file components or
+//! YAML keys with dots in them, and that the key may not have empty components,
+//! i.e. two dots in a row.
+//!
+//! Might make sense to disallow slashes, too?
+//!
+//! For each component, the following are tried, in this order, until one is true:
+//!
+//! TODO move all this to the main file where it's relevant.
+//!
+//! 1. Is there a directory with this name at the current level from the datastore root?
+//! 2. Is there file with this name and a .yaml extension at this level?
+//! 3. Is there a file with this name and a .yml extension at this level?
+//! 4. If we've matched a file (2 or 3 above), is there a key at the current level?
+//!
+//! If at any point these all fail, data parsing will fail.
+use std::fmt::Display;
+use thiserror::Error;
+
+/// Delimiter on which components of a keypath are split.
+const KEYPATH_DELIMITER: &str = ".";
+
+/// Characters that are disallowed in a keypath and will cause failure.
+const INVALID_CHARACTERS: &[char] = &['.', '/'];
+
+/// Error type for keypaths.
+///
+/// Only one error at this time, and that is for parsing failure.
+#[derive(Error, Debug)]
+pub enum KeyPathParseError {
+    /// keypath string is invalid
+    #[error("keypath contains slashes or empty components")]
+    InvalidKeyPath,
+}
+
+/// Internal struct for parsing and managing keypath components.
+///
+/// The only way to construct is [`try_from`].
+#[derive(Debug)]
+pub(crate) struct KeyPath {
+    /// Components of the keypath used to navigate datastore.
+    components: Vec<String>,
+}
+
+/// Check a single keypath component for validity and return a String if it's valid.
+fn check_and_convert(component: &str) -> Result<String, KeyPathParseError> {
+    if component.is_empty() || component.contains(INVALID_CHARACTERS) {
+        Err(KeyPathParseError::InvalidKeyPath)
+    } else {
+        Ok(component.into())
+    }
+}
+
+impl TryFrom<&str> for KeyPath {
+    type Error = KeyPathParseError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Ok(Self {
+            components: value
+                .split(KEYPATH_DELIMITER)
+                .map(check_and_convert)
+                .collect::<Result<Vec<_>, _>>()?,
+        })
+    }
+}
+
+impl Display for KeyPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.components.join("."))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid() {
+        let input = "this.is.a.valid.keypath";
+        let result = KeyPath::try_from(input).unwrap();
+        let expected = vec!["this", "is", "a", "valid", "keypath"];
+        assert_eq!(result.components, expected);
+    }
+
+    #[test]
+    fn err_contains_slash() {
+        let input = "contains/slash";
+        let result = KeyPath::try_from(input).unwrap_err();
+        assert!(matches!(result, KeyPathParseError::InvalidKeyPath));
+    }
+
+    #[test]
+    fn err_empty_component_middle() {
+        let input = "has..component";
+        let result = KeyPath::try_from(input).unwrap_err();
+        assert!(matches!(result, KeyPathParseError::InvalidKeyPath));
+    }
+
+    #[test]
+    fn err_empty_component_first() {
+        let input = ".has.component";
+        let result = KeyPath::try_from(input).unwrap_err();
+        assert!(matches!(result, KeyPathParseError::InvalidKeyPath));
+    }
+
+    #[test]
+    fn err_empty_component_last() {
+        let input = "has.component.";
+        let result = KeyPath::try_from(input).unwrap_err();
+        assert!(matches!(result, KeyPathParseError::InvalidKeyPath));
+    }
+}

--- a/src/keypath.rs
+++ b/src/keypath.rs
@@ -35,12 +35,12 @@
 //! The above should print out:
 //!
 //! ```text
-//! a.yml       | ["b", "c"]
-//! a.yaml      | ["b", "c"]
-//! a/b.yml     | ["c"]
-//! a/b.yaml    | ["c"]
-//! a/b/c.yml   | []
-//! a/b/c.yaml  | []
+//! a/b/c.yaml | []
+//! a/b/c.yml  | []
+//! a/b.yaml   | ["c"]
+//! a/b.yml    | ["c"]
+//! a.yaml     | ["b", "c"]
+//! a.yml      | ["b", "c"]
 //! ```
 //!
 //! This iterator can then be used to search the keystore with the given precedence: directories > files > keys.
@@ -59,21 +59,23 @@
 //! The above should print out:
 //!
 //! ```text
-//! a/b/c.yaml | []
-//! a/b/c.yml  | []
-//! a/b.yaml   | ["c"]
-//! a/b.yml    | ["c"]
-//! a.yaml     | ["b", "c"]
-//! a.yml      | ["b", "c"]
+//! a.yml       | ["b", "c"]
+//! a.yaml      | ["b", "c"]
+//! a/b.yml     | ["c"]
+//! a/b.yaml    | ["c"]
+//! a/b/c.yml   | []
+//! a/b/c.yaml  | []
 //! ```
 use std::{ffi::OsStr, path::PathBuf};
 use thiserror::Error;
 
 /// Default file extensions for the iterator.
-pub static DEFAULT_EXTENSIONS: &[&str] = &["yaml", "yml"];
+///
+/// It's just `yaml` and `yml`.
+pub const DEFAULT_EXTENSIONS: [&str; 2] = ["yaml", "yml"];
 
 /// Delimiter on which components of a keypath are split.
-const DELIMITER: &str = ".";
+pub const DELIMITER: &str = ".";
 
 /// Characters that are disallowed in a keypath and will cause failure.
 const INVALID_CHARACTERS: &[char] = &['.', '/'];
@@ -108,14 +110,13 @@ fn validate_and_trim(component: &str) -> Result<&str, KeyPathParseError> {
 }
 
 impl TryFrom<&str> for KeyPath {
+    /// The error returned if any components are empty or contain invalid characters.
     type Error = KeyPathParseError;
 
     /// Construct a [`KeyPath`] from a string.
     ///
     /// A valid `KeyPath` is a string with some components separated by `.`.
     /// See the [module-level documentation](crate::keypath) for details.
-    ///
-    /// # Errors
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         // Split up value, validate and trim it, then put it back together.
         Ok(Self {
@@ -129,21 +130,80 @@ impl TryFrom<&str> for KeyPath {
 }
 
 impl std::fmt::Display for KeyPath {
+    /// Format the keypath in its internal, parsed state.
+    /// In most cases this should be identical to the source string.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.raw)
     }
 }
 
 impl KeyPath {
-    /// Return an iterator over the keypath components using the [default list of extensions][DEFAULT_EXTENSIONS].
+    /// Return an iterator over the keypath using the [default list of extensions][DEFAULT_EXTENSIONS].
     ///
+    /// # Example
     ///
+    /// ```rust
+    /// # use yaml_datastore::keypath::KeyPath;
+    /// let keypath = KeyPath::try_from("a.b.c").expect("keypath parsed");
+    /// for (path, keys) in keypath.iter() {
+    ///     // do something
+    /// }
+    /// ```
+    ///
+    /// See the [module-level documentation](crate::keypath) for examples.
     #[must_use]
     pub fn iter(&self) -> impl DoubleEndedIterator<Item = (PathBuf, Vec<&str>)> {
-        self.iter_extensions(DEFAULT_EXTENSIONS)
+        self.iter_extensions(&DEFAULT_EXTENSIONS)
     }
 
-    /// Return an iterator
+    /// Return an iterator over the keypath using the single specified extension.
+    ///
+    /// The extension should **not** contain a leading `.`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use yaml_datastore::keypath::KeyPath;
+    /// let keypath = KeyPath::try_from("a.b.c").expect("keypath parsed");
+    /// for (path, keys) in keypath.iter_extension("json") {
+    ///     // do something
+    /// }
+    /// ```
+    pub fn iter_extension<S: AsRef<OsStr> + ?Sized>(
+        &self,
+        extension: &S,
+    ) -> impl DoubleEndedIterator<Item = (PathBuf, Vec<&str>)> {
+        let paths = self.components();
+        let keys = self.components();
+
+        // This is intentional. We want an ExactSizeIterator so we can freely use
+        // rev() on the returned iterator, but we can't if we use a RangeInclusve.
+        #[allow(clippy::range_plus_one)]
+        let range = (1..paths.len() + 1).rev();
+        std::iter::zip(
+            range.clone().map(move |i| {
+                paths[0..i]
+                    .iter()
+                    .collect::<PathBuf>()
+                    .with_extension(extension)
+            }),
+            range.clone().map(move |i| keys[i..].to_vec()),
+        )
+    }
+
+    /// Return an iterator over the keypath components with the passed in file extensions.
+    ///
+    /// File extensions should **not** contain a leading `.`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use yaml_datastore::keypath::KeyPath;
+    /// let keypath = KeyPath::try_from("a.b.c").expect("keypath parsed");
+    /// for (path, keys) in keypath.iter_extensions(&vec!["yaml", "json"]) {
+    ///     // do something
+    /// }
+    /// ```
     pub fn iter_extensions<S: AsRef<OsStr>>(
         &self,
         extensions: &[S],
@@ -169,6 +229,14 @@ impl KeyPath {
     /// Return the parsed components as a list of strings.
     ///
     /// While not intended for use externally at this point, it could be useful for introspection.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use yaml_datastore::keypath::KeyPath;
+    /// let keypath = KeyPath::try_from("a.b.c").expect("keypath parsed");
+    /// assert_eq!(keypath.components(), vec!["a", "b", "c"]);
+    /// ```
     #[must_use]
     pub fn components(&self) -> Vec<&str> {
         self.raw.split(DELIMITER).collect()
@@ -222,6 +290,20 @@ mod tests {
             (PathBuf::from("this.yml"), vec!["is", "a", "keypath"]),
         ];
         expected.reverse();
+        assert_eq!(zipped, expected);
+    }
+
+    #[test]
+    fn iterator_with_extension() {
+        let input = "this.is.a.keypath";
+        let result = KeyPath::try_from(input).expect("key parsed");
+        let zipped: Vec<_> = result.iter_extension("yaml").collect();
+        let expected = vec![
+            (PathBuf::from("this/is/a/keypath.yaml"), vec![]),
+            (PathBuf::from("this/is/a.yaml"), vec!["keypath"]),
+            (PathBuf::from("this/is.yaml"), vec!["a", "keypath"]),
+            (PathBuf::from("this.yaml"), vec!["is", "a", "keypath"]),
+        ];
         assert_eq!(zipped, expected);
     }
 

--- a/src/keypath.rs
+++ b/src/keypath.rs
@@ -18,11 +18,16 @@
 //! 4. If we've matched a file (2 or 3 above), is there a key at the current level?
 //!
 //! If at any point these all fail, data parsing will fail.
-use std::fmt::Display;
+use core::num;
+use std::{
+    fmt::Display,
+    iter::{Zip, zip},
+    path::{self, Path, PathBuf},
+};
 use thiserror::Error;
 
 /// Delimiter on which components of a keypath are split.
-const KEYPATH_DELIMITER: &str = ".";
+const DELIMITER: &str = ".";
 
 /// Characters that are disallowed in a keypath and will cause failure.
 const INVALID_CHARACTERS: &[char] = &['.', '/'];
@@ -62,10 +67,10 @@ impl TryFrom<&str> for KeyPath {
         // Split up value, validate and trim it, then put it back together.
         Ok(Self {
             raw: value
-                .split(KEYPATH_DELIMITER)
+                .split(DELIMITER)
                 .map(validate_and_trim)
                 .collect::<Result<Vec<_>, _>>()?
-                .join(KEYPATH_DELIMITER),
+                .join(DELIMITER),
         })
     }
 }
@@ -76,11 +81,193 @@ impl Display for KeyPath {
     }
 }
 
+const EXTENSIONS: &[&str] = &["yaml", "yml"];
+
 impl KeyPath {
     pub fn components(&self) -> Vec<&str> {
-        self.raw.split(KEYPATH_DELIMITER).collect()
+        self.raw.split(DELIMITER).collect()
     }
+
+    // pub fn split_iter(&self) -> impl Iterator<Item = (PathBuf, Vec<&str>)> {
+    //     let c = self.components();
+    //     let c2 = c.clone();
+    //     let range = (1..=c.len()).rev();
+    //     zip(
+    //         range.clone().flat_map(move |i| {
+    //             let path: PathBuf = c[0..i].iter().collect();
+    //             [path.with_extension("yaml"), path.with_extension("yml")]
+    //         }),
+    //         range
+    //             .clone()
+    //             .flat_map(move |i| [c2[i..].to_vec(), c2[i..].to_vec()]),
+    //     )
+    // }
+
+    // pub fn split_iter2(&self) -> impl Iterator<Item = (PathBuf, Vec<&str>)> {
+    //     let c = self.components();
+    //     let c2 = c.clone();
+    //     let range = (1..=c.len()).rev();
+    //     zip(
+    //         range.clone().map(move |i| c[0..i].iter().collect()),
+    //         range.clone().map(move |i| c2[i..].to_vec()),
+    //     )
+    //     .flat_map(|pair: (PathBuf, _)| {
+    //         [
+    //             (pair.0.with_extension("yaml"), pair.1.clone()),
+    //             (pair.0.with_extension("yml"), pair.1),
+    //         ]
+    //     })
+    // }
+
+    /// Return an iterator
+    pub fn iter(&self) -> impl Iterator<Item = (PathBuf, Vec<&str>)> {
+        let paths = self.components();
+        let keys = self.components();
+        let range = (1..=paths.len()).rev();
+        zip(
+            range.clone().map(move |i| paths[0..i].iter().collect()),
+            range.clone().map(move |i| keys[i..].to_vec()),
+        )
+        .flat_map(|pair: (PathBuf, _)| {
+            EXTENSIONS
+                .iter()
+                .map(move |e| (pair.0.with_extension(e), pair.1.clone()))
+        })
+    }
+
+    // pub fn split_iter2(&self) -> impl Iterator<Item = (PathBuf, Vec<&str>)> {
+    //     let c1 = self.components();
+    //     let c2 = self.components();
+    //     let range = (1..=c1.len()).rev();
+    //     let path_iterator = range.clone().map(move |i| c1[0..i].iter().collect());
+    //     let key_iterator = range.clone().map(move |i| c2[i..].to_vec());
+    //     fn add_extensions(v: (PathBuf, Vec<&str>)) -> impl Iterator<Item = (PathBuf, Vec<&str>)> {
+    //         EXTENSIONS
+    //             .iter()
+    //             .map(move |e| (v.0.with_extension(e), v.1.clone()))
+    //     }
+    //     zip(path_iterator, key_iterator).flat_map(add_extensions)
+    // }
+
+    // pub fn split_iter4(&self) -> impl Iterator<Item = (PathBuf, Vec<&str>)> {
+    //     let components = self.components();
+    //     let mut ret = vec![];
+    //     for index in (1..=components.len()).rev() {
+    //         let path: PathBuf = components[0..index].iter().collect();
+    //         let key_vec = components[index..].to_vec();
+    //         for extension in EXTENSIONS {
+    //             ret.push((path.with_extension(extension), key_vec.clone()));
+    //         }
+    //     }
+    //     ret.into_iter()
+    // }
 }
+
+#[cfg(test)]
+mod adhoc_tests {
+    use super::*;
+
+    #[test]
+    fn adhoc() {
+        let input = "this.is.a.keypath";
+        let result = KeyPath::try_from(input).unwrap();
+        let zipped: Vec<_> = result.iter().collect();
+        let expected = vec![
+            (PathBuf::from("this/is/a/keypath.yaml"), vec![]),
+            (PathBuf::from("this/is/a/keypath.yml"), vec![]),
+            (PathBuf::from("this/is/a.yaml"), vec!["keypath"]),
+            (PathBuf::from("this/is/a.yml"), vec!["keypath"]),
+            (PathBuf::from("this/is.yaml"), vec!["a", "keypath"]),
+            (PathBuf::from("this/is.yml"), vec!["a", "keypath"]),
+            (PathBuf::from("this.yaml"), vec!["is", "a", "keypath"]),
+            (PathBuf::from("this.yml"), vec!["is", "a", "keypath"]),
+        ];
+        assert_eq!(zipped, expected);
+
+        // for (a, b) in zipped {
+        //     println!("{}, {:?}", a.display(), b);
+        // }
+    }
+
+    // #[test]
+    // fn adhoc2() {
+    //     let input = "this.is.a.keypath";
+    //     let result = KeyPath::try_from(input).unwrap();
+    //     let zipped: Vec<_> = result.split_iter2().collect();
+    //     let expected = vec![
+    //         (PathBuf::from("this/is/a/keypath.yaml"), vec![]),
+    //         (PathBuf::from("this/is/a/keypath.yml"), vec![]),
+    //         (PathBuf::from("this/is/a.yaml"), vec!["keypath"]),
+    //         (PathBuf::from("this/is/a.yml"), vec!["keypath"]),
+    //         (PathBuf::from("this/is.yaml"), vec!["a", "keypath"]),
+    //         (PathBuf::from("this/is.yml"), vec!["a", "keypath"]),
+    //         (PathBuf::from("this.yaml"), vec!["is", "a", "keypath"]),
+    //         (PathBuf::from("this.yml"), vec!["is", "a", "keypath"]),
+    //     ];
+    //     assert_eq!(zipped, expected);
+
+    //     // for (a, b) in zipped {
+    //     //     println!("{}, {:?}", a.display(), b);
+    //     // }
+    // }
+
+    // #[test]
+    // fn adhoc3() {
+    //     let input = "this.is.a.keypath";
+    //     let result = KeyPath::try_from(input).unwrap();
+    //     let zipped: Vec<_> = result.iter().collect();
+    //     let expected = vec![
+    //         (PathBuf::from("this/is/a/keypath.yaml"), vec![]),
+    //         (PathBuf::from("this/is/a/keypath.yml"), vec![]),
+    //         (PathBuf::from("this/is/a.yaml"), vec!["keypath"]),
+    //         (PathBuf::from("this/is/a.yml"), vec!["keypath"]),
+    //         (PathBuf::from("this/is.yaml"), vec!["a", "keypath"]),
+    //         (PathBuf::from("this/is.yml"), vec!["a", "keypath"]),
+    //         (PathBuf::from("this.yaml"), vec!["is", "a", "keypath"]),
+    //         (PathBuf::from("this.yml"), vec!["is", "a", "keypath"]),
+    //     ];
+    //     assert_eq!(zipped, expected);
+
+    //     // for (a, b) in zipped {
+    //     //     println!("{}, {:?}", a.display(), b);
+    //     // }
+    // }
+
+    // #[test]
+    // fn adhoc4() {
+    //     let input = "this.is.a.keypath";
+    //     let result = KeyPath::try_from(input).unwrap();
+    //     let zipped: Vec<_> = result.split_iter4().collect();
+    //     let expected = vec![
+    //         (PathBuf::from("this/is/a/keypath.yaml"), vec![]),
+    //         (PathBuf::from("this/is/a/keypath.yml"), vec![]),
+    //         (PathBuf::from("this/is/a.yaml"), vec!["keypath"]),
+    //         (PathBuf::from("this/is/a.yml"), vec!["keypath"]),
+    //         (PathBuf::from("this/is.yaml"), vec!["a", "keypath"]),
+    //         (PathBuf::from("this/is.yml"), vec!["a", "keypath"]),
+    //         (PathBuf::from("this.yaml"), vec!["is", "a", "keypath"]),
+    //         (PathBuf::from("this.yml"), vec!["is", "a", "keypath"]),
+    //     ];
+    //     assert_eq!(zipped, expected);
+
+    //     // for (a, b) in zipped {
+    //     //     println!("{}, {:?}", a.display(), b);
+    //     // }
+    // }
+}
+
+// struct Iterator<'a> {
+//     keypath: &'a KeyPath,
+//     index: u32,
+// }
+
+// impl<'a> Iterator for KeyPathIterator<'a> {
+//     type Item = (std::path::PathBuf, Vec<String>);
+
+//     fn next(&mut self) -> Option<Self::Item> {
+//         if index > 0
+//     }
+// }
 
 #[cfg(test)]
 mod tests {

--- a/src/keypath.rs
+++ b/src/keypath.rs
@@ -1,30 +1,54 @@
-//! Parsing for keypaths, which are of the form:
+//! Parsing for keypaths, which are flexible keys for navigating a datastore.
+//! Keypath components may represent either path components or keys within a YAML file.
 //!
-//! a.b.c.d
+//! # Format
+//! Keypaths are of the form `a.b.c.d`, where `a`, `b`, `c`, and `d` are keys, and `.` are delimiters.
+//! Forward-slash characters (i.e. `/`) must not be contained in a path, and no components may be empty.
+//! This means in effect that the [delimiter](DELIMITER) (`.`) may not appear twice in a row or appear at the beginning or end of a keypath.
 //!
-//! The only things precluded from this design are file components or
-//! YAML keys with dots in them, and that the key may not have empty components,
-//! i.e. two dots in a row.
+//! ## Spaces
+//! If a keypath contains spaces at the beginning or end of a component, those spaces will be stripped.
+//! For example, ` a . b . c . d ` will be parsed as `a.b.c.d.`.
 //!
-//! Might make sense to disallow slashes, too?
+//! ## Invalid Examples
+//! The following are some examples of invalid keypaths:
 //!
-//! For each component, the following are tried, in this order, until one is true:
+//! * `contains/slash`
+//! * `empty.component..in.middle`
+//! * `whitespace.component. .in.middle`
+//! * `.empty.component.at.beginning`
+//! * `empty.component.at.end.`
 //!
-//! TODO move all this to the main file where it's relevant.
+//! # Usage
+//! Keypaths provide [iterators](`KeyPath::iter`) that can be used to iterate over all possible interpretations of a keypath.
 //!
-//! 1. Is there a directory with this name at the current level from the datastore root?
-//! 2. Is there file with this name and a .yaml extension at this level?
-//! 3. Is there a file with this name and a .yml extension at this level?
-//! 4. If we've matched a file (2 or 3 above), is there a key at the current level?
+//! ```rust
+//! use yaml_datastore::keypath::KeyPath;
 //!
-//! If at any point these all fail, data parsing will fail.
-use core::num;
-use std::{
-    fmt::Display,
-    iter::{Zip, zip},
-    path::{self, Path, PathBuf},
-};
+//! let keypath = KeyPath::try_from("a.b.c").expect("keypath parsed");
+//! for (path, keys) in keypath.iter() {
+//!     println!("{:10} | {:?}", path.display(), keys);
+//! }
+//! ```
+//!
+//! The above should print out:
+//!
+//! ```text
+//! a/b/c.yaml | []
+//! a/b/c.yml  | []
+//! a/b.yaml   | ["c"]
+//! a/b.yml    | ["c"]
+//! a.yaml     | ["b", "c"]
+//! a.yml      | ["b", "c"]
+//! ```
+//!
+//! This iterator can then be used to search the keystore with the given precedence: directories > files > keys.
+
+use std::{ffi::OsStr, path::PathBuf};
 use thiserror::Error;
+
+/// Default file extensions for the iterator.
+pub static DEFAULT_EXTENSIONS: &[&str] = &["yaml", "yml"];
 
 /// Delimiter on which components of a keypath are split.
 const DELIMITER: &str = ".";
@@ -44,15 +68,16 @@ pub enum KeyPathParseError {
 
 /// Internal struct for parsing and managing keypath components.
 ///
-/// The only way to construct is [`try_from`].
+/// Construct using [`try_from`](KeyPath::try_from).
 #[derive(Debug)]
-pub(crate) struct KeyPath {
+pub struct KeyPath {
     /// Raw string that components point to.
     raw: String,
 }
 
 /// Check a single keypath component for validity and return a String if it's valid.
 fn validate_and_trim(component: &str) -> Result<&str, KeyPathParseError> {
+    let component = component.trim();
     if component.is_empty() || component.contains(INVALID_CHARACTERS) {
         Err(KeyPathParseError::InvalidKeyPath)
     } else {
@@ -63,6 +88,12 @@ fn validate_and_trim(component: &str) -> Result<&str, KeyPathParseError> {
 impl TryFrom<&str> for KeyPath {
     type Error = KeyPathParseError;
 
+    /// Construct a [`KeyPath`] from a string.
+    ///
+    /// A valid `KeyPath` is a string with some components separated by `.`.
+    /// See the [module-level documentation](crate::keypath) for details.
+    ///
+    /// # Errors
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         // Split up value, validate and trim it, then put it back together.
         Ok(Self {
@@ -75,102 +106,64 @@ impl TryFrom<&str> for KeyPath {
     }
 }
 
-impl Display for KeyPath {
+impl std::fmt::Display for KeyPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.raw)
     }
 }
 
-const EXTENSIONS: &[&str] = &["yaml", "yml"];
-
 impl KeyPath {
-    pub fn components(&self) -> Vec<&str> {
-        self.raw.split(DELIMITER).collect()
+    /// Return an iterator over the keypath components using the [default list of extensions][DEFAULT_EXTENSIONS].
+    ///
+    ///
+    pub fn iter(&self) -> impl Iterator<Item = (PathBuf, Vec<&str>)> {
+        self.iter_extensions(DEFAULT_EXTENSIONS)
     }
 
-    // pub fn split_iter(&self) -> impl Iterator<Item = (PathBuf, Vec<&str>)> {
-    //     let c = self.components();
-    //     let c2 = c.clone();
-    //     let range = (1..=c.len()).rev();
-    //     zip(
-    //         range.clone().flat_map(move |i| {
-    //             let path: PathBuf = c[0..i].iter().collect();
-    //             [path.with_extension("yaml"), path.with_extension("yml")]
-    //         }),
-    //         range
-    //             .clone()
-    //             .flat_map(move |i| [c2[i..].to_vec(), c2[i..].to_vec()]),
-    //     )
-    // }
-
-    // pub fn split_iter2(&self) -> impl Iterator<Item = (PathBuf, Vec<&str>)> {
-    //     let c = self.components();
-    //     let c2 = c.clone();
-    //     let range = (1..=c.len()).rev();
-    //     zip(
-    //         range.clone().map(move |i| c[0..i].iter().collect()),
-    //         range.clone().map(move |i| c2[i..].to_vec()),
-    //     )
-    //     .flat_map(|pair: (PathBuf, _)| {
-    //         [
-    //             (pair.0.with_extension("yaml"), pair.1.clone()),
-    //             (pair.0.with_extension("yml"), pair.1),
-    //         ]
-    //     })
-    // }
-
     /// Return an iterator
-    pub fn iter(&self) -> impl Iterator<Item = (PathBuf, Vec<&str>)> {
+    pub fn iter_extensions<S: AsRef<OsStr>>(
+        &self,
+        extensions: &[S],
+    ) -> impl Iterator<Item = (PathBuf, Vec<&str>)> {
         let paths = self.components();
         let keys = self.components();
         let range = (1..=paths.len()).rev();
-        zip(
+        std::iter::zip(
             range.clone().map(move |i| paths[0..i].iter().collect()),
             range.clone().map(move |i| keys[i..].to_vec()),
         )
         .flat_map(|pair: (PathBuf, _)| {
-            EXTENSIONS
+            extensions
                 .iter()
                 .map(move |e| (pair.0.with_extension(e), pair.1.clone()))
         })
     }
 
-    // pub fn split_iter2(&self) -> impl Iterator<Item = (PathBuf, Vec<&str>)> {
-    //     let c1 = self.components();
-    //     let c2 = self.components();
-    //     let range = (1..=c1.len()).rev();
-    //     let path_iterator = range.clone().map(move |i| c1[0..i].iter().collect());
-    //     let key_iterator = range.clone().map(move |i| c2[i..].to_vec());
-    //     fn add_extensions(v: (PathBuf, Vec<&str>)) -> impl Iterator<Item = (PathBuf, Vec<&str>)> {
-    //         EXTENSIONS
-    //             .iter()
-    //             .map(move |e| (v.0.with_extension(e), v.1.clone()))
-    //     }
-    //     zip(path_iterator, key_iterator).flat_map(add_extensions)
-    // }
-
-    // pub fn split_iter4(&self) -> impl Iterator<Item = (PathBuf, Vec<&str>)> {
-    //     let components = self.components();
-    //     let mut ret = vec![];
-    //     for index in (1..=components.len()).rev() {
-    //         let path: PathBuf = components[0..index].iter().collect();
-    //         let key_vec = components[index..].to_vec();
-    //         for extension in EXTENSIONS {
-    //             ret.push((path.with_extension(extension), key_vec.clone()));
-    //         }
-    //     }
-    //     ret.into_iter()
-    // }
+    /// Return the parsed components as a list of strings.
+    ///
+    /// While not intended for use externally at this point, it could be useful for introspection.
+    pub fn components(&self) -> Vec<&str> {
+        self.raw.split(DELIMITER).collect()
+    }
 }
 
 #[cfg(test)]
-mod adhoc_tests {
+mod tests {
     use super::*;
 
     #[test]
-    fn adhoc() {
+    fn valid() {
+        let input = "this.is.a.valid.keypath";
+        let result = KeyPath::try_from(input).expect("key parsed");
+        let expected = vec!["this", "is", "a", "valid", "keypath"];
+        assert_eq!(result.components(), expected);
+        assert_eq!(result.to_string(), input);
+    }
+
+    #[test]
+    fn iterator() {
         let input = "this.is.a.keypath";
-        let result = KeyPath::try_from(input).unwrap();
+        let result = KeyPath::try_from(input).expect("key parsed");
         let zipped: Vec<_> = result.iter().collect();
         let expected = vec![
             (PathBuf::from("this/is/a/keypath.yaml"), vec![]),
@@ -183,109 +176,31 @@ mod adhoc_tests {
             (PathBuf::from("this.yml"), vec!["is", "a", "keypath"]),
         ];
         assert_eq!(zipped, expected);
-
-        // for (a, b) in zipped {
-        //     println!("{}, {:?}", a.display(), b);
-        // }
     }
 
-    // #[test]
-    // fn adhoc2() {
-    //     let input = "this.is.a.keypath";
-    //     let result = KeyPath::try_from(input).unwrap();
-    //     let zipped: Vec<_> = result.split_iter2().collect();
-    //     let expected = vec![
-    //         (PathBuf::from("this/is/a/keypath.yaml"), vec![]),
-    //         (PathBuf::from("this/is/a/keypath.yml"), vec![]),
-    //         (PathBuf::from("this/is/a.yaml"), vec!["keypath"]),
-    //         (PathBuf::from("this/is/a.yml"), vec!["keypath"]),
-    //         (PathBuf::from("this/is.yaml"), vec!["a", "keypath"]),
-    //         (PathBuf::from("this/is.yml"), vec!["a", "keypath"]),
-    //         (PathBuf::from("this.yaml"), vec!["is", "a", "keypath"]),
-    //         (PathBuf::from("this.yml"), vec!["is", "a", "keypath"]),
-    //     ];
-    //     assert_eq!(zipped, expected);
-
-    //     // for (a, b) in zipped {
-    //     //     println!("{}, {:?}", a.display(), b);
-    //     // }
-    // }
-
-    // #[test]
-    // fn adhoc3() {
-    //     let input = "this.is.a.keypath";
-    //     let result = KeyPath::try_from(input).unwrap();
-    //     let zipped: Vec<_> = result.iter().collect();
-    //     let expected = vec![
-    //         (PathBuf::from("this/is/a/keypath.yaml"), vec![]),
-    //         (PathBuf::from("this/is/a/keypath.yml"), vec![]),
-    //         (PathBuf::from("this/is/a.yaml"), vec!["keypath"]),
-    //         (PathBuf::from("this/is/a.yml"), vec!["keypath"]),
-    //         (PathBuf::from("this/is.yaml"), vec!["a", "keypath"]),
-    //         (PathBuf::from("this/is.yml"), vec!["a", "keypath"]),
-    //         (PathBuf::from("this.yaml"), vec!["is", "a", "keypath"]),
-    //         (PathBuf::from("this.yml"), vec!["is", "a", "keypath"]),
-    //     ];
-    //     assert_eq!(zipped, expected);
-
-    //     // for (a, b) in zipped {
-    //     //     println!("{}, {:?}", a.display(), b);
-    //     // }
-    // }
-
-    // #[test]
-    // fn adhoc4() {
-    //     let input = "this.is.a.keypath";
-    //     let result = KeyPath::try_from(input).unwrap();
-    //     let zipped: Vec<_> = result.split_iter4().collect();
-    //     let expected = vec![
-    //         (PathBuf::from("this/is/a/keypath.yaml"), vec![]),
-    //         (PathBuf::from("this/is/a/keypath.yml"), vec![]),
-    //         (PathBuf::from("this/is/a.yaml"), vec!["keypath"]),
-    //         (PathBuf::from("this/is/a.yml"), vec!["keypath"]),
-    //         (PathBuf::from("this/is.yaml"), vec!["a", "keypath"]),
-    //         (PathBuf::from("this/is.yml"), vec!["a", "keypath"]),
-    //         (PathBuf::from("this.yaml"), vec!["is", "a", "keypath"]),
-    //         (PathBuf::from("this.yml"), vec!["is", "a", "keypath"]),
-    //     ];
-    //     assert_eq!(zipped, expected);
-
-    //     // for (a, b) in zipped {
-    //     //     println!("{}, {:?}", a.display(), b);
-    //     // }
-    // }
-}
-
-// struct Iterator<'a> {
-//     keypath: &'a KeyPath,
-//     index: u32,
-// }
-
-// impl<'a> Iterator for KeyPathIterator<'a> {
-//     type Item = (std::path::PathBuf, Vec<String>);
-
-//     fn next(&mut self) -> Option<Self::Item> {
-//         if index > 0
-//     }
-// }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
     #[test]
-    fn valid() {
-        let input = "this.is.a.valid.keypath";
-        let result = KeyPath::try_from(input).unwrap();
-        let expected = vec!["this", "is", "a", "valid", "keypath"];
-        assert_eq!(result.components(), expected);
-        assert_eq!(result.to_string(), input);
+    fn iterator_with_explicit_extensions() {
+        let input = "this.is.a.keypath";
+        let result = KeyPath::try_from(input).expect("key parsed");
+        let extensions = vec!["json", "xml"];
+        let zipped: Vec<_> = result.iter_extensions(&extensions).collect();
+        let expected = vec![
+            (PathBuf::from("this/is/a/keypath.json"), vec![]),
+            (PathBuf::from("this/is/a/keypath.xml"), vec![]),
+            (PathBuf::from("this/is/a.json"), vec!["keypath"]),
+            (PathBuf::from("this/is/a.xml"), vec!["keypath"]),
+            (PathBuf::from("this/is.json"), vec!["a", "keypath"]),
+            (PathBuf::from("this/is.xml"), vec!["a", "keypath"]),
+            (PathBuf::from("this.json"), vec!["is", "a", "keypath"]),
+            (PathBuf::from("this.xml"), vec!["is", "a", "keypath"]),
+        ];
+        assert_eq!(zipped, expected);
     }
 
     #[test]
     fn valid_with_spaces() {
         let input = " this . is . a . valid . keypath ";
-        let result = KeyPath::try_from(input).unwrap();
+        let result = KeyPath::try_from(input).expect("key parsed");
         let expected = vec!["this", "is", "a", "valid", "keypath"];
         assert_eq!(result.components(), expected);
         assert_eq!(result.to_string(), "this.is.a.valid.keypath");
@@ -294,28 +209,35 @@ mod tests {
     #[test]
     fn err_contains_slash() {
         let input = "contains/slash";
-        let result = KeyPath::try_from(input).unwrap_err();
+        let result = KeyPath::try_from(input).expect_err("invalid keypath");
         assert!(matches!(result, KeyPathParseError::InvalidKeyPath));
     }
 
     #[test]
     fn err_empty_component_middle() {
-        let input = "has..component";
-        let result = KeyPath::try_from(input).unwrap_err();
+        let input = "empty.component..in.middle";
+        let result = KeyPath::try_from(input).expect_err("invalid keypath");
+        assert!(matches!(result, KeyPathParseError::InvalidKeyPath));
+    }
+
+    #[test]
+    fn err_whitespace_component_middle() {
+        let input = "whitespace.component. .in.middle";
+        let result = KeyPath::try_from(input).expect_err("invalid keypath");
         assert!(matches!(result, KeyPathParseError::InvalidKeyPath));
     }
 
     #[test]
     fn err_empty_component_first() {
-        let input = ".has.component";
-        let result = KeyPath::try_from(input).unwrap_err();
+        let input = ".empty.component.at.beginning";
+        let result = KeyPath::try_from(input).expect_err("invalid keypath");
         assert!(matches!(result, KeyPathParseError::InvalidKeyPath));
     }
 
     #[test]
     fn err_empty_component_last() {
-        let input = "has.component.";
-        let result = KeyPath::try_from(input).unwrap_err();
+        let input = "empty.component.at.end.";
+        let result = KeyPath::try_from(input).expect_err("invalid keypath");
         assert!(matches!(result, KeyPathParseError::InvalidKeyPath));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,13 @@
 //!
 //! [00]: https://yaml.org/
 
+use keypath::{KeyPath, KeyPathParseError};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_yaml::{Mapping, value::from_value};
 use std::path::{Path, PathBuf};
 use thiserror::Error;
+
+pub mod keypath;
 
 /// Error type for this crate.
 #[derive(Error, Debug)]
@@ -30,6 +33,10 @@ pub enum Error {
     /// An empty key vector was passed to [`Datastore::get_with_key_vec`].
     #[error("empty key vector")]
     EmptyKeyVector,
+
+    /// Error returned from the keypath parser during parsing.
+    #[error(transparent)]
+    KeyPathError(#[from] KeyPathParseError),
 }
 
 fn yaml_mapping_recurse<T, S>(map: &Mapping, keys: &[S]) -> Result<T, Error>
@@ -65,16 +72,16 @@ mod yaml_mapping_recurse_tests {
     #[test]
     fn empty_keys() {
         let yaml = "";
-        let data: Mapping = from_str(&yaml).unwrap();
-        let value = yaml_mapping_recurse::<bool, &str>(&data, &vec![]).unwrap_err();
+        let data: Mapping = from_str(yaml).unwrap();
+        let value = yaml_mapping_recurse::<bool, &str>(&data, &[]).unwrap_err();
         assert!(matches!(value, Error::EmptyKeyVector));
     }
 
     #[test]
     fn missing_key_in_data() {
         let yaml = "";
-        let data: Mapping = from_str(&yaml).unwrap();
-        let value = yaml_mapping_recurse::<bool, &str>(&data, &vec!["something"]).unwrap_err();
+        let data: Mapping = from_str(yaml).unwrap();
+        let value = yaml_mapping_recurse::<bool, &str>(&data, &["something"]).unwrap_err();
         assert!(matches!(value, Error::KeyNotFound));
     }
 
@@ -85,14 +92,14 @@ mod yaml_mapping_recurse_tests {
         key2: true
         key3: false
         ";
-        let data: Mapping = from_str(&yaml).unwrap();
+        let data: Mapping = from_str(yaml).unwrap();
 
-        let value: bool = yaml_mapping_recurse(&data, &vec!["key1"]).unwrap();
-        assert_eq!(value, false);
-        let value: bool = yaml_mapping_recurse(&data, &vec!["key2"]).unwrap();
-        assert_eq!(value, true);
-        let value: bool = yaml_mapping_recurse(&data, &vec!["key3"]).unwrap();
-        assert_eq!(value, false);
+        let value: bool = yaml_mapping_recurse(&data, &["key1"]).unwrap();
+        assert!(!value);
+        let value: bool = yaml_mapping_recurse(&data, &["key2"]).unwrap();
+        assert!(value);
+        let value: bool = yaml_mapping_recurse(&data, &["key3"]).unwrap();
+        assert!(!value);
     }
 
     #[test]
@@ -102,15 +109,16 @@ mod yaml_mapping_recurse_tests {
             middle:
                 inner: true
         ";
-        let data: Mapping = from_str(&yaml).unwrap();
-        let value: bool = yaml_mapping_recurse(&data, &vec!["outer", "middle", "inner"]).unwrap();
-        assert_eq!(value, true);
+        let data: Mapping = from_str(yaml).unwrap();
+        let value: bool = yaml_mapping_recurse(&data, &["outer", "middle", "inner"]).unwrap();
+        assert!(value);
     }
 }
 
 /// Handle for a YAML datastore.
 ///
-/// Open with [open](Datastore::open).
+/// Open with [`open()`](Datastore::open).
+/// Access with [`get()`](Datastore::get).
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Datastore {
     /// The filesystem root of the datastore. All lookups are done relative to this path.
@@ -123,6 +131,66 @@ impl Datastore {
     /// At present, this doesn't actually perform any operations.
     pub fn open<P: Into<PathBuf>>(path: P) -> Datastore {
         Datastore { root: path.into() }
+    }
+
+    /// Helper function to support [`Self::get`] that attempts to access the given path and YAML key.
+    fn try_get<P, S, T>(path: P, keys: &[S]) -> Option<T>
+    where
+        P: AsRef<Path>,
+        S: AsRef<str> + serde_yaml::mapping::Index,
+        T: DeserializeOwned,
+    {
+        let file_string = std::fs::read_to_string(path).ok()?;
+        if keys.is_empty() {
+            Some(serde_yaml::from_str(&file_string).ok()?)
+        } else {
+            let mapping: Mapping = serde_yaml::from_str(&file_string).ok()?;
+            yaml_mapping_recurse(&mapping, keys).ok()?
+        }
+    }
+
+    /// Get a value from the datastore given a keypath.
+    ///
+    /// This method parses the given string into a [`KeyPath`] and then iterates over the possible path
+    /// and key combinations until it finds a match or has exhausted them. It starts with the longest
+    /// possible path and shortest key and works backwards.
+    ///
+    /// More explicitly, it will search each possible path for the given keypath, starting with the longest.
+    /// If it finds a file that matches, it attempts to use the remainder of the keypath as keys into the YAML file.
+    /// If the full keypath matches a file path, then the entire YAML file data is returned.
+    ///
+    /// See the documentation for [keypath] for more information on how the keypath is used to generate combinations.
+    ///
+    /// # Examples
+    ///
+    /// For a keypath of `a.b.c.d`, the first match of the following would be returned if found:
+    ///
+    /// 1. The entire contents of file `a/b/c/d.yaml`.
+    /// 2. The contents of the key `d` in `a/b/c.yaml`.
+    /// 3. The contents of the key `c.d` in `a/b.yaml`.
+    /// 4. The contents of the key `b.c.d` in `a.yaml`.
+    ///
+    /// For the above, the dot-notation for YAML keys implies nesting. So for `b.c.d`:
+    ///
+    /// ```text
+    /// b:
+    ///   c:
+    ///     d: 42
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::KeyPathError`] if `keypath` is invalid.
+    ///
+    /// Returns [`Error::KeyNotFound`] if the given key was not found.
+    pub fn get<T: DeserializeOwned>(&self, keypath: &str) -> Result<T, Error> {
+        let keypath = KeyPath::try_from(keypath)?;
+        for (path, keys) in keypath.iter() {
+            if let Some(data) = Self::try_get(self.root.join(path), &keys) {
+                return Ok(data);
+            }
+        }
+        Err(Error::KeyNotFound)
     }
 
     /// Get all the data from a given YAML file in the datastore.
@@ -264,6 +332,22 @@ mod tests {
     }
 
     #[test]
+    fn test_keypath_complete() {
+        let reference = TestFormat {
+            name: "Complete".into(),
+            id: 1,
+            rating: Some(1.0),
+            complete: true,
+            tags: vec!["complete".into(), "done".into(), "finished".into()],
+            nested: Some(TestNested { value: true }),
+        };
+
+        let datastore: Datastore = Datastore::open(TEST_DATASTORE_PATH);
+        let parsed: TestFormat = datastore.get("complete").unwrap();
+        assert_eq!(parsed, reference);
+    }
+
+    #[test]
     fn test_complete() {
         let reference = TestFormat {
             name: "Complete".into(),
@@ -299,16 +383,16 @@ mod tests {
     fn test_with_single_bool_key() {
         let datastore: Datastore = Datastore::open(TEST_DATASTORE_PATH);
         let result: bool = datastore.get_with_key("complete.yaml", "complete").unwrap();
-        assert_eq!(result, true);
+        assert!(result);
     }
 
     #[test]
     fn nested_bool() {
         let datastore: Datastore = Datastore::open(TEST_DATASTORE_PATH);
         let result: bool = datastore
-            .get_with_key_vec("complete.yaml", &vec!["nested", "value"])
+            .get_with_key_vec("complete.yaml", &["nested", "value"])
             .unwrap();
-        assert_eq!(result, true);
+        assert!(result);
     }
 
     #[test]


### PR DESCRIPTION
Add a new `keypath` module that handles converting a dot-notation keypath and produces an iterator that gets used by the main datastore code. Then the datastore code has been enhanced to provide a new `get()` method that uses a keypath.